### PR TITLE
Updated auth0 redirect to work on first login

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -15,7 +15,7 @@
     "gatsby": "^2.19.12",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "gatsby-theme-contentful": "^0.0.3"
+    "gatsby-theme-contentful": "^0.0.4"
   },
   "devDependencies": {
     "prettier": "^1.19.1"

--- a/gatsby-theme-contentful/package.json
+++ b/gatsby-theme-contentful/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/ethriel3695/gatsby-theme-contentful.git"
   },
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "index.js",
   "license": "MIT",
   "peerDependencies": {

--- a/gatsby-theme-contentful/src/templates/index.js
+++ b/gatsby-theme-contentful/src/templates/index.js
@@ -1,14 +1,14 @@
 import React, { Fragment } from 'react';
+import { navigate } from 'gatsby';
 import WidgetHandler from '../components/WidgetHandler';
 import { Auth0Provider } from '../react-auth0-spa';
-import history from '../utils/history';
 import AuthContainer from '../components/UI/AuthContainer';
 import NoAuthContainer from '../components/UI/NoAuthContainer';
 
 const isBrowser = typeof window !== `undefined`;
 
 const onRedirectCallback = appState => {
-  history.push(
+  navigate(
     appState && appState.targetUrl
       ? appState.targetUrl
       : window.location.pathname,


### PR DESCRIPTION
The authentication redirect with history was not working in production. Since gatsby has a built in `navigate` function I chose to use this instead and it works as intended.