### PR TITLE
Refactor Components to be reusable

### DIFF
--- a/gatsby-theme-contentful/package.json
+++ b/gatsby-theme-contentful/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/ethriel3695/gatsby-theme-contentful.git"
   },
-  "version": "0.1.19",
+  "version": "0.1.20",
   "main": "index.js",
   "license": "MIT",
   "peerDependencies": {

--- a/gatsby-theme-contentful/package.json
+++ b/gatsby-theme-contentful/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/ethriel3695/gatsby-theme-contentful.git"
   },
-  "version": "0.1.20",
+  "version": "0.1.21",
   "main": "index.js",
   "license": "MIT",
   "peerDependencies": {

--- a/gatsby-theme-contentful/src/components/Header/Header.js
+++ b/gatsby-theme-contentful/src/components/Header/Header.js
@@ -76,11 +76,13 @@ const Header = ({
   if (brandLogo) {
     if (!brandLogo.childImageSharp && brandLogo.extension === 'svg') {
       logo = brandLogo.publicURL;
-      BrandContainer = <img src={logo} className="headerLogoSize" alt={alt} />;
+      BrandContainer = (
+        <img src={logo} className="header-logo-size" alt={alt} />
+      );
     } else {
       logo = brandLogo.childImageSharp.fluid;
       BrandContainer = (
-        <Image fluid={logo} className="headerLogoSize" alt={alt} />
+        <Image fluid={logo} className="header-logo-size" alt={alt} />
       );
     }
   } else {

--- a/gatsby-theme-contentful/src/components/Section/HeroSection.js
+++ b/gatsby-theme-contentful/src/components/Section/HeroSection.js
@@ -9,11 +9,11 @@ export const HeroSection = ({ section }) => {
         {section.file && <Image fluid={section.file.fluid} />}
       </div>
       <div className="container">
-        <h2 className="text-center py-8" key={`${section.title}`}>
+        <h2 className="py-8" key={`${section.title}`}>
           {section.title}
         </h2>
         {section.description && (
-          <div className="text-lg text-gray-800 text-center mb-2">
+          <div className="text-lg text-gray-800 mb-2">
             {documentToReactComponents(
               section.description.json
               // , {

--- a/gatsby-theme-contentful/src/components/Section/Section.js
+++ b/gatsby-theme-contentful/src/components/Section/Section.js
@@ -12,7 +12,6 @@ export default class Section extends React.Component {
 
   renderSection() {
     const section = this.props.section;
-    console.log(section);
     switch (this.props.section.__typename) {
       case 'ContentfulHero':
         return <HeroSection section={section} />;

--- a/gatsby-theme-contentful/src/components/Section/SectionLayout.js
+++ b/gatsby-theme-contentful/src/components/Section/SectionLayout.js
@@ -9,7 +9,6 @@ export const SectionLayout = ({
   isContainer = false,
 }) => {
   const { title, description, subHeader, caption } = section;
-  console.log(section);
   return (
     <div className={isContainer ? `container ${className}` : ` ${className}`}>
       <h3>{title}</h3>


### PR DESCRIPTION
I've noticed that some of the components in the Theme are duplicates or very close

Spend some time identifying similarities and create smaller components where possible to reduce code duplication
Once components are identified, break them out into subtasks in reference to this issue to reduce the scope of the refactor
https://github.com/ethriel3695/gatsby-theme-contentful/issues/60
open

https://trello.com/c/5HIYOQ9C/83-refactor-components-to-be-reusable

Development Projects

2020-10-03T07:12:22.132Z

RE